### PR TITLE
Add signing method check to JWT validation

### DIFF
--- a/internal/utils/jwt.go
+++ b/internal/utils/jwt.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"errors"
-	"github.com/golang-jwt/jwt/v5"
-	"time"
+        "errors"
+        "fmt"
+        "github.com/golang-jwt/jwt/v5"
+        "time"
 )
 
 var jwtKey = []byte("secret-key")
@@ -32,17 +33,20 @@ func GenerateJWT(userID string) (string, error) {
 }
 
 func ValidateJWT(tokenString string) (string, error) {
-	claims := &Claims{}
+        claims := &Claims{}
 
-	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
-		return jwtKey, nil
-	})
-	if err != nil {
-		return "", err
-	}
+        token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+                if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+                        return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+                }
+                return jwtKey, nil
+        })
+        if err != nil {
+                return "", err
+        }
 
-	if !token.Valid {
-		return "", errors.New("invalid token")
-	}
-	return claims.UserID, nil
+        if !token.Valid {
+                return "", errors.New("invalid token")
+        }
+        return claims.UserID, nil
 }


### PR DESCRIPTION
## Summary
- ensure JWT validation only accepts HMAC-signed tokens

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f204baf6c83289190f7d4d1f15874