### PR TITLE
Add JWT auth middleware and secure transaction routes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/gin-gonic/gin"
 	"hexagonal-go/internal/adapters/http"
+	"hexagonal-go/internal/adapters/http/middleware"
 	"hexagonal-go/internal/adapters/repository"
 	"hexagonal-go/internal/config"
 	"hexagonal-go/internal/core/services"
@@ -34,9 +35,13 @@ func main() {
 	r.POST("/register", userHandler.Register)
 	r.POST("/login", userHandler.Login)
 
-	// Endpoint transaction
-	r.POST("/deposit", transactionHandler.Deposit)
-	r.POST("/withdraw", transactionHandler.Withdraw)
+	// Endpoint transaction with authentication middleware
+	auth := r.Group("/")
+	auth.Use(middleware.AuthMiddleware())
+	{
+		auth.POST("/deposit", transactionHandler.Deposit)
+		auth.POST("/withdraw", transactionHandler.Withdraw)
+	}
 
 	// Jalankan server pada port 8080
 	r.Run(":8080")

--- a/internal/adapters/http/middleware/auth.go
+++ b/internal/adapters/http/middleware/auth.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"hexagonal-go/internal/utils"
+)
+
+// AuthMiddleware validates JWT tokens from the Authorization header.
+// It expects the header to be in the format: "Bearer <token>".
+func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authorization header missing"})
+			return
+		}
+
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization header format"})
+			return
+		}
+
+		userID, err := utils.ValidateJWT(parts[1])
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
+			return
+		}
+
+		// store userID in context for downstream handlers
+		c.Set("userID", userID)
+		c.Next()
+	}
+}


### PR DESCRIPTION
## Summary
- add authentication middleware to validate JWT tokens
- protect deposit and withdraw routes with auth middleware

## Testing
- `go fmt cmd/main.go`
- `go fmt internal/adapters/http/middleware/auth.go`
- `go build ./...` *(failed: command hung, aborted)*
- `go test ./...` *(failed: command hung, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689f2d14e7fc8328b62314481c12431f