### PR TITLE
Load DB and JWT config from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Database configuration
+DB_HOST=localhost
+DB_USER=admin
+DB_PASSWORD=root
+DB_NAME=hexago
+DB_PORT=5432
+DB_SSLMODE=disable
+
+# JWT configuration
+JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Hexagonal Go
+
+This application demonstrates a basic Hexagonal architecture using Gin and Gorm.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and adjust the values:
+   ```bash
+   cp .env.example .env
+   ```
+   Required variables:
+   - `DB_HOST`
+   - `DB_USER`
+   - `DB_PASSWORD`
+   - `DB_NAME`
+   - `DB_PORT`
+   - `DB_SSLMODE`
+   - `JWT_SECRET`
+
+2. Install dependencies:
+   ```bash
+   go mod tidy
+   ```
+
+3. Run the application:
+   ```bash
+   go run cmd/main.go
+   ```
+
+The server starts on port 8080.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
+	github.com/joho/godotenv v1.5.1
 	golang.org/x/crypto v0.23.0
 	gorm.io/driver/postgres v1.5.11
 	gorm.io/gorm v1.25.12

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,13 +2,28 @@ package config
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"hexagonal-go/internal/core/domain"
 )
 
 func ConnectDB() (*gorm.DB, error) {
-	dsn := "host=localhost user=admin password=root dbname=hexago port=5432 sslmode=disable"
+	_ = godotenv.Load()
+
+	host := os.Getenv("DB_HOST")
+	user := os.Getenv("DB_USER")
+	password := os.Getenv("DB_PASSWORD")
+	name := os.Getenv("DB_NAME")
+	port := os.Getenv("DB_PORT")
+	sslmode := os.Getenv("DB_SSLMODE")
+	if sslmode == "" {
+		sslmode = "disable"
+	}
+
+	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s", host, user, password, name, port, sslmode)
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect database: %w", err)

--- a/internal/utils/jwt.go
+++ b/internal/utils/jwt.go
@@ -1,13 +1,21 @@
 package utils
 
 import (
-        "errors"
-        "fmt"
-        "github.com/golang-jwt/jwt/v5"
-        "time"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/joho/godotenv"
+	"time"
 )
 
-var jwtKey = []byte("secret-key")
+var jwtKey []byte
+
+func init() {
+	_ = godotenv.Load()
+	jwtKey = []byte(os.Getenv("JWT_SECRET"))
+}
 
 type Claims struct {
 	UserID string `json:"user_id"`
@@ -33,20 +41,20 @@ func GenerateJWT(userID string) (string, error) {
 }
 
 func ValidateJWT(tokenString string) (string, error) {
-        claims := &Claims{}
+	claims := &Claims{}
 
-        token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
-                if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-                        return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-                }
-                return jwtKey, nil
-        })
-        if err != nil {
-                return "", err
-        }
+	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return jwtKey, nil
+	})
+	if err != nil {
+		return "", err
+	}
 
-        if !token.Valid {
-                return "", errors.New("invalid token")
-        }
-        return claims.UserID, nil
+	if !token.Valid {
+		return "", errors.New("invalid token")
+	}
+	return claims.UserID, nil
 }


### PR DESCRIPTION
## Summary
- read database connection settings from env vars using godotenv
- read JWT signing key from `JWT_SECRET`
- add `.env.example` and document setup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f357334b48328a540acbdd3a5cc43