### PR TITLE
test: add user service tests

### DIFF
--- a/internal/core/services/user_service_impl_test.go
+++ b/internal/core/services/user_service_impl_test.go
@@ -1,63 +1,72 @@
 package services
 
 import (
-	"golang.org/x/crypto/bcrypt"
-	"hexagonal-go/internal/core/domain"
-	"testing"
+        "errors"
+        "testing"
+
+        "golang.org/x/crypto/bcrypt"
+        "hexagonal-go/internal/core/domain"
+        "hexagonal-go/internal/core/ports"
 )
 
 type mockUserRepository struct {
-	createFn            func(user *domain.User) error
-	findByPhoneNumberFn func(phoneNumber string) (*domain.User, error)
+        createFn            func(user *domain.User) error
+        findByPhoneNumberFn func(phoneNumber string) (*domain.User, error)
 }
 
+var _ ports.UserRepository = (*mockUserRepository)(nil)
+
 func (m *mockUserRepository) Create(user *domain.User) error {
-	if m.createFn != nil {
-		return m.createFn(user)
-	}
-	return nil
+        if m.createFn != nil {
+                return m.createFn(user)
+        }
+        return nil
 }
 
 func (m *mockUserRepository) FindByPhoneNumber(phoneNumber string) (*domain.User, error) {
-	if m.findByPhoneNumberFn != nil {
-		return m.findByPhoneNumberFn(phoneNumber)
-	}
-	return nil, nil
+        if m.findByPhoneNumberFn != nil {
+                return m.findByPhoneNumberFn(phoneNumber)
+        }
+        return nil, errors.New("not implemented")
 }
 
-func TestUserServiceRegisterHashesPin(t *testing.T) {
-	var createdUser *domain.User
-	repo := &mockUserRepository{
-		createFn: func(u *domain.User) error {
-			createdUser = u
-			return nil
-		},
-	}
-	service := NewUserService(repo)
-	user := &domain.User{Pin: "1234"}
-	if err := service.Register(user); err != nil {
-		t.Fatalf("Register returned error: %v", err)
-	}
-	if createdUser.Pin == "1234" {
-		t.Fatalf("expected pin to be hashed")
-	}
-	if err := bcrypt.CompareHashAndPassword([]byte(createdUser.Pin), []byte("1234")); err != nil {
-		t.Fatalf("stored pin does not match original: %v", err)
-	}
+func TestUserServiceRegister(t *testing.T) {
+        var savedUser *domain.User
+        repo := &mockUserRepository{
+                createFn: func(u *domain.User) error {
+                        savedUser = u
+                        return nil
+                },
+        }
+        service := NewUserService(repo)
+
+        if err := service.Register(&domain.User{PhoneNumber: "08123", Pin: "1234"}); err != nil {
+                t.Fatalf("Register returned error: %v", err)
+        }
+        if savedUser == nil {
+                t.Fatalf("expected Create to be called")
+        }
+        if savedUser.Pin == "1234" {
+                t.Fatalf("expected pin to be hashed")
+        }
+        if err := bcrypt.CompareHashAndPassword([]byte(savedUser.Pin), []byte("1234")); err != nil {
+                t.Fatalf("stored pin does not match original: %v", err)
+        }
 }
 
 func TestUserServiceLogin(t *testing.T) {
-	hashed, _ := bcrypt.GenerateFromPassword([]byte("1234"), bcrypt.DefaultCost)
-	repo := &mockUserRepository{
-		findByPhoneNumberFn: func(phone string) (*domain.User, error) {
-			return &domain.User{Pin: string(hashed)}, nil
-		},
-	}
-	service := NewUserService(repo)
-	if _, err := service.Login("08123", "1234"); err != nil {
-		t.Fatalf("expected login to succeed, got %v", err)
-	}
-	if _, err := service.Login("08123", "4321"); err == nil {
-		t.Fatalf("expected error for invalid pin")
-	}
+        hashed, _ := bcrypt.GenerateFromPassword([]byte("1234"), bcrypt.DefaultCost)
+        repo := &mockUserRepository{
+                findByPhoneNumberFn: func(phone string) (*domain.User, error) {
+                        return &domain.User{PhoneNumber: phone, Pin: string(hashed)}, nil
+                },
+        }
+        service := NewUserService(repo)
+
+        if _, err := service.Login("08123", "1234"); err != nil {
+                t.Fatalf("expected login to succeed, got %v", err)
+        }
+        if _, err := service.Login("08123", "4321"); err == nil {
+                t.Fatalf("expected error for invalid pin")
+        }
 }


### PR DESCRIPTION
## Summary
- add user service tests for Register and Login with a mocked repository

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f3a0637bc8328a311276f9d9ee9b0