### PR TITLE
Add transaction retrieval endpoint and tests

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ func main() {
 	{
 		auth.POST("/deposit", transactionHandler.Deposit)
 		auth.POST("/withdraw", transactionHandler.Withdraw)
+		auth.GET("/transactions/:user_id", transactionHandler.GetTransactions)
 	}
 
 	// Jalankan server pada port 8080

--- a/internal/adapters/http/transaction_handler.go
+++ b/internal/adapters/http/transaction_handler.go
@@ -60,3 +60,18 @@ func (h *TransactionHandler) Withdraw(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "SUCCESS", "result": tx})
 }
+
+func (h *TransactionHandler) GetTransactions(c *gin.Context) {
+	userIDParam := c.Param("user_id")
+	userID, err := uuid.Parse(userIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user id"})
+		return
+	}
+	txs, err := h.transactionService.GetTransactionsByUser(userID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "SUCCESS", "result": txs})
+}

--- a/internal/core/services/transaction_service_impl.go
+++ b/internal/core/services/transaction_service_impl.go
@@ -67,3 +67,7 @@ func (s *TransactionService) Withdraw(userID uuid.UUID, amount float64, remarks 
 	}
 	return &tx, nil
 }
+
+func (s *TransactionService) GetTransactionsByUser(userID uuid.UUID) ([]domain.Transaction, error) {
+	return s.transactionRepo.FindByUser(userID)
+}

--- a/internal/core/services/transaction_service_impl_test.go
+++ b/internal/core/services/transaction_service_impl_test.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+	"hexagonal-go/internal/core/domain"
+	"hexagonal-go/internal/core/ports"
+)
+
+type mockTransactionRepository struct {
+	createFn     func(tx *domain.Transaction) error
+	findByUserFn func(userID uuid.UUID) ([]domain.Transaction, error)
+}
+
+var _ ports.TransactionRepository = (*mockTransactionRepository)(nil)
+
+func (m *mockTransactionRepository) Create(tx *domain.Transaction) error {
+	if m.createFn != nil {
+		return m.createFn(tx)
+	}
+	return nil
+}
+
+func (m *mockTransactionRepository) FindByUser(userID uuid.UUID) ([]domain.Transaction, error) {
+	if m.findByUserFn != nil {
+		return m.findByUserFn(userID)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func TestTransactionService_GetTransactionsByUser(t *testing.T) {
+	userID := uuid.New()
+	expected := []domain.Transaction{{UserID: userID}}
+	repo := &mockTransactionRepository{
+		findByUserFn: func(id uuid.UUID) ([]domain.Transaction, error) {
+			if id != userID {
+				t.Errorf("expected userID %v, got %v", userID, id)
+			}
+			return expected, nil
+		},
+	}
+	service := NewTransactionService(repo, nil)
+	txs, err := service.GetTransactionsByUser(userID)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !reflect.DeepEqual(txs, expected) {
+		t.Fatalf("expected %v, got %v", expected, txs)
+	}
+}
+
+func TestTransactionService_GetTransactionsByUserError(t *testing.T) {
+	userID := uuid.New()
+	repo := &mockTransactionRepository{
+		findByUserFn: func(id uuid.UUID) ([]domain.Transaction, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	service := NewTransactionService(repo, nil)
+	_, err := service.GetTransactionsByUser(userID)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add GetTransactionsByUser service method
- expose HTTP handler and GET /transactions/:user_id route
- add unit tests for transaction service

## Testing
- `go test ./internal/core/services -run TestTransactionService_GetTransactionsByUser -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f741ea7288328bccf1954d7c1384e