### PR TITLE
Add profile lookup via user ID

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,6 +43,7 @@ func main() {
 		auth.POST("/withdraw", transactionHandler.Withdraw)
 		auth.POST("/transfer", transactionHandler.Transfer)
 		auth.GET("/transactions/:user_id", transactionHandler.GetTransactions)
+		auth.GET("/profile", userHandler.Profile)
 	}
 
 	// Jalankan server pada port 8080

--- a/internal/adapters/http/user_handler.go
+++ b/internal/adapters/http/user_handler.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"hexagonal-go/internal/core/domain"
 	"hexagonal-go/internal/core/services"
 	"hexagonal-go/internal/utils"
@@ -67,4 +68,28 @@ func (h *UserHandler) Login(c *gin.Context) {
 			"refresh_token": "", // Jika ada refresh token
 		},
 	})
+}
+
+func (h *UserHandler) Profile(c *gin.Context) {
+	userIDVal, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "userID not found"})
+		return
+	}
+	userIDStr, ok := userIDVal.(string)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid userID type"})
+		return
+	}
+	id, err := uuid.Parse(userIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user id"})
+		return
+	}
+	user, err := h.userService.GetByID(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "SUCCESS", "result": user})
 }

--- a/internal/adapters/repository/user_repository_impl.go
+++ b/internal/adapters/repository/user_repository_impl.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"hexagonal-go/internal/core/domain"
 )
@@ -26,5 +27,11 @@ func (r *UserRepositoryImpl) Create(user *domain.User) error {
 func (r *UserRepositoryImpl) FindByPhoneNumber(phoneNumber string) (*domain.User, error) {
 	var user domain.User
 	err := r.db.Where("phone_number = ?", phoneNumber).First(&user).Error
+	return &user, err
+}
+
+func (r *UserRepositoryImpl) FindByID(id uuid.UUID) (*domain.User, error) {
+	var user domain.User
+	err := r.db.Where("user_id = ?", id).First(&user).Error
 	return &user, err
 }

--- a/internal/core/ports/user_repository.go
+++ b/internal/core/ports/user_repository.go
@@ -1,10 +1,12 @@
 package ports
 
 import (
+	"github.com/google/uuid"
 	"hexagonal-go/internal/core/domain"
 )
 
 type UserRepository interface {
 	Create(user *domain.User) error
 	FindByPhoneNumber(phoneNumber string) (*domain.User, error)
+	FindByID(id uuid.UUID) (*domain.User, error)
 }

--- a/internal/core/services/user_service_impl.go
+++ b/internal/core/services/user_service_impl.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 	"hexagonal-go/internal/core/domain"
 	"hexagonal-go/internal/core/ports"
@@ -33,4 +34,8 @@ func (s *UserService) Login(phoneNumber, pin string) (*domain.User, error) {
 		return nil, errors.New("invalid pin")
 	}
 	return user, nil
+}
+
+func (s *UserService) GetByID(id uuid.UUID) (*domain.User, error) {
+	return s.userRepo.FindByID(id)
 }

--- a/internal/core/services/user_service_impl_test.go
+++ b/internal/core/services/user_service_impl_test.go
@@ -1,72 +1,102 @@
 package services
 
 import (
-        "errors"
-        "testing"
+	"errors"
+	"testing"
 
-        "golang.org/x/crypto/bcrypt"
-        "hexagonal-go/internal/core/domain"
-        "hexagonal-go/internal/core/ports"
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+	"hexagonal-go/internal/core/domain"
+	"hexagonal-go/internal/core/ports"
 )
 
 type mockUserRepository struct {
-        createFn            func(user *domain.User) error
-        findByPhoneNumberFn func(phoneNumber string) (*domain.User, error)
+	createFn            func(user *domain.User) error
+	findByPhoneNumberFn func(phoneNumber string) (*domain.User, error)
+	findByIDFn          func(id uuid.UUID) (*domain.User, error)
 }
 
 var _ ports.UserRepository = (*mockUserRepository)(nil)
 
 func (m *mockUserRepository) Create(user *domain.User) error {
-        if m.createFn != nil {
-                return m.createFn(user)
-        }
-        return nil
+	if m.createFn != nil {
+		return m.createFn(user)
+	}
+	return nil
 }
 
 func (m *mockUserRepository) FindByPhoneNumber(phoneNumber string) (*domain.User, error) {
-        if m.findByPhoneNumberFn != nil {
-                return m.findByPhoneNumberFn(phoneNumber)
-        }
-        return nil, errors.New("not implemented")
+	if m.findByPhoneNumberFn != nil {
+		return m.findByPhoneNumberFn(phoneNumber)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockUserRepository) FindByID(id uuid.UUID) (*domain.User, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(id)
+	}
+	return nil, errors.New("not implemented")
 }
 
 func TestUserServiceRegister(t *testing.T) {
-        var savedUser *domain.User
-        repo := &mockUserRepository{
-                createFn: func(u *domain.User) error {
-                        savedUser = u
-                        return nil
-                },
-        }
-        service := NewUserService(repo)
+	var savedUser *domain.User
+	repo := &mockUserRepository{
+		createFn: func(u *domain.User) error {
+			savedUser = u
+			return nil
+		},
+	}
+	service := NewUserService(repo)
 
-        if err := service.Register(&domain.User{PhoneNumber: "08123", Pin: "1234"}); err != nil {
-                t.Fatalf("Register returned error: %v", err)
-        }
-        if savedUser == nil {
-                t.Fatalf("expected Create to be called")
-        }
-        if savedUser.Pin == "1234" {
-                t.Fatalf("expected pin to be hashed")
-        }
-        if err := bcrypt.CompareHashAndPassword([]byte(savedUser.Pin), []byte("1234")); err != nil {
-                t.Fatalf("stored pin does not match original: %v", err)
-        }
+	if err := service.Register(&domain.User{PhoneNumber: "08123", Pin: "1234"}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if savedUser == nil {
+		t.Fatalf("expected Create to be called")
+	}
+	if savedUser.Pin == "1234" {
+		t.Fatalf("expected pin to be hashed")
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(savedUser.Pin), []byte("1234")); err != nil {
+		t.Fatalf("stored pin does not match original: %v", err)
+	}
 }
 
 func TestUserServiceLogin(t *testing.T) {
-        hashed, _ := bcrypt.GenerateFromPassword([]byte("1234"), bcrypt.DefaultCost)
-        repo := &mockUserRepository{
-                findByPhoneNumberFn: func(phone string) (*domain.User, error) {
-                        return &domain.User{PhoneNumber: phone, Pin: string(hashed)}, nil
-                },
-        }
-        service := NewUserService(repo)
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("1234"), bcrypt.DefaultCost)
+	repo := &mockUserRepository{
+		findByPhoneNumberFn: func(phone string) (*domain.User, error) {
+			return &domain.User{PhoneNumber: phone, Pin: string(hashed)}, nil
+		},
+	}
+	service := NewUserService(repo)
 
-        if _, err := service.Login("08123", "1234"); err != nil {
-                t.Fatalf("expected login to succeed, got %v", err)
-        }
-        if _, err := service.Login("08123", "4321"); err == nil {
-                t.Fatalf("expected error for invalid pin")
-        }
+	if _, err := service.Login("08123", "1234"); err != nil {
+		t.Fatalf("expected login to succeed, got %v", err)
+	}
+	if _, err := service.Login("08123", "4321"); err == nil {
+		t.Fatalf("expected error for invalid pin")
+	}
+}
+
+func TestUserServiceGetByID(t *testing.T) {
+	userID := uuid.New()
+	expected := &domain.User{UserID: userID}
+	repo := &mockUserRepository{
+		findByIDFn: func(id uuid.UUID) (*domain.User, error) {
+			if id != userID {
+				t.Errorf("expected id %v, got %v", userID, id)
+			}
+			return expected, nil
+		},
+	}
+	service := NewUserService(repo)
+	user, err := service.GetByID(userID)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if user != expected {
+		t.Fatalf("expected %v, got %v", expected, user)
+	}
 }


### PR DESCRIPTION
## Summary
- support retrieving users by ID in repository and service
- expose /profile endpoint to return authenticated user's data
- add tests for user service GetByID

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0894698808328be5e870c72492172