### PR TITLE
Add refresh token support with new endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ func main() {
 	// Endpoint user
 	r.POST("/register", userHandler.Register)
 	r.POST("/login", userHandler.Login)
+	r.POST("/refresh", userHandler.RefreshToken)
 
 	// Endpoint transaction with authentication middleware
 	auth := r.Group("/")

--- a/internal/adapters/http/user_handler.go
+++ b/internal/adapters/http/user_handler.go
@@ -54,10 +54,16 @@ func (h *UserHandler) Login(c *gin.Context) {
 		return
 	}
 
-	// Generate JWT token menggunakan fungsi dari utils
+	// Generate JWT dan refresh token menggunakan fungsi dari utils
 	token, err := utils.GenerateJWT(user.UserID.String()) // Konversi UUID ke string
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
+		return
+	}
+
+	refreshToken, err := utils.GenerateRefreshToken(user.UserID.String())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate refresh token"})
 		return
 	}
 
@@ -65,7 +71,7 @@ func (h *UserHandler) Login(c *gin.Context) {
 		"status": "SUCCESS",
 		"result": gin.H{
 			"access_token":  token,
-			"refresh_token": "", // Jika ada refresh token
+			"refresh_token": refreshToken,
 		},
 	})
 }
@@ -92,4 +98,45 @@ func (h *UserHandler) Profile(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "SUCCESS", "result": user})
+}
+
+// RefreshToken handler untuk endpoint /refresh
+func (h *UserHandler) RefreshToken(c *gin.Context) {
+	var request struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
+		return
+	}
+
+	userID, err := utils.ValidateRefreshToken(request.RefreshToken)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid refresh token"})
+		return
+	}
+
+	// Opsional: revoke refresh token lama untuk menghindari reuse
+	utils.RevokeRefreshToken(request.RefreshToken)
+
+	token, err := utils.GenerateJWT(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
+		return
+	}
+
+	newRefresh, err := utils.GenerateRefreshToken(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate refresh token"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": "SUCCESS",
+		"result": gin.H{
+			"access_token":  token,
+			"refresh_token": newRefresh,
+		},
+	})
 }

--- a/internal/utils/jwt.go
+++ b/internal/utils/jwt.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/joho/godotenv"
@@ -11,6 +12,13 @@ import (
 )
 
 var jwtKey []byte
+
+// refreshTokenStore menyimpan refresh token yang valid untuk
+// memungkinkan kontrol revokasi sederhana.
+var refreshTokenStore = struct {
+	sync.RWMutex
+	tokens map[string]string
+}{tokens: make(map[string]string)}
 
 func init() {
 	_ = godotenv.Load()
@@ -57,4 +65,71 @@ func ValidateJWT(tokenString string) (string, error) {
 		return "", errors.New("invalid token")
 	}
 	return claims.UserID, nil
+}
+
+// RefreshClaims adalah klaim khusus untuk refresh token dengan masa berlaku
+// yang lebih panjang.
+type RefreshClaims struct {
+	UserID string `json:"user_id"`
+	jwt.RegisteredClaims
+}
+
+// GenerateRefreshToken membuat refresh token baru dan menyimpannya di store.
+func GenerateRefreshToken(userID string) (string, error) {
+	expirationTime := time.Now().Add(7 * 24 * time.Hour)
+
+	claims := &RefreshClaims{
+		UserID: userID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expirationTime),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(jwtKey)
+	if err != nil {
+		return "", err
+	}
+
+	refreshTokenStore.Lock()
+	refreshTokenStore.tokens[tokenString] = userID
+	refreshTokenStore.Unlock()
+
+	return tokenString, nil
+}
+
+// ValidateRefreshToken memvalidasi refresh token dan memastikan token tersebut
+// belum direvoke.
+func ValidateRefreshToken(tokenString string) (string, error) {
+	claims := &RefreshClaims{}
+
+	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return jwtKey, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if !token.Valid {
+		return "", errors.New("invalid token")
+	}
+
+	refreshTokenStore.RLock()
+	_, exists := refreshTokenStore.tokens[tokenString]
+	refreshTokenStore.RUnlock()
+	if !exists {
+		return "", errors.New("token revoked")
+	}
+
+	return claims.UserID, nil
+}
+
+// RevokeRefreshToken menghapus refresh token dari store.
+func RevokeRefreshToken(tokenString string) {
+	refreshTokenStore.Lock()
+	delete(refreshTokenStore.tokens, tokenString)
+	refreshTokenStore.Unlock()
 }


### PR DESCRIPTION
## Summary
- add refresh token generation and validation with in-memory revocation store
- issue refresh tokens during login and add `/refresh` handler
- expose `POST /refresh` route for obtaining new access tokens

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a292952fac8328ad992884ab1ed17b